### PR TITLE
Pass matcher into parser to ignore specific paths

### DIFF
--- a/esi_example_app/src/index.html
+++ b/esi_example_app/src/index.html
@@ -12,6 +12,7 @@
       <esi:include src="https://mock-s3.edgecompute.app/_fragments/content.html"/>
       <esi:include src="https://mock-s3.edgecompute.app/_fragments/doesnotexist.html" alt="https://mock-s3.edgecompute.app/_fragments/content.html"/>
       <esi:include src="https://mock-s3.edgecompute.app/_fragments/doesnotexist.html" onerror="continue"/>
+      <esi:include src="https://mock-s3.edgecompute.app/ignore">this should be here, since it's ignored</esi:include>
     </div>
   </body>
 </html>

--- a/esi_example_app/src/main.rs
+++ b/esi_example_app/src/main.rs
@@ -31,7 +31,9 @@ fn handle_request(req: Request) -> Result<(), Error> {
         .map(|c| c.subtype() == mime::HTML)
         .unwrap_or(false)
     {
-        let config = esi::Configuration::default().with_recursion();
+        let config = esi::Configuration::default()
+            .with_recursion()
+            .with_matcher(&|src| !src.contains("ignore"));
 
         let processor = Processor::new(config);
 


### PR DESCRIPTION
One way to resolve #7 

```
        let config = esi::Configuration::default()
            .with_recursion()
            .with_matcher(&|src| !src.contains("ignore"));
```