### PR TITLE
using `.wait()` instead of `.poll()` loop

### DIFF
--- a/esi/Cargo.toml
+++ b/esi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esi"
-version = "0.4.0"
+version = "0.4.1"
 description = "A streaming parser and executor for Edge Side Includes"
 repository = "https://github.com/fastly/esi"
 license = "MIT"


### PR DESCRIPTION
The approach of using `pop-front()`, `poll()` and the subsequent `push-front()` for pending requests in the loop is using too much CPU (especially if the backend response is slow). Since the responses from `esi:include` requests are serialized, we can use `wait()` to achieve the same result, but with a much smaller CPU usage. In my testing with 30 `esi:include` statements the CPU went down at least 4x in the "best" case, when backend responses were quick - cached in a chained VCL service (200ms -> 50ms). In the "worst" case, when backend responses took seconds or even timing out it was registering the same seconds for vCPU. In such cases the CPU usage went down up to 300x (15s -> 50ms).