### PR TITLE
Add configuration parameters for tag names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0-pre1"
 authors = ["Kailan Blanks <kblanks@fastly.com>"]
 license = "MIT"
 edition = "2018"

--- a/esi/src/config.rs
+++ b/esi/src/config.rs
@@ -8,8 +8,8 @@
 #[allow(clippy::return_self_not_must_use)]
 #[derive(Clone, Debug)]
 pub struct Configuration {
-    /// The XML namespace to use when scanning for ESI tags. Defaults to `esi`.
-    pub namespace: String,
+    // Define the tag names that the processor will operate on.
+    pub tag_names: TagNames,
     /// For working with non-HTML ESI templates, e.g. JSON files, this option allows you to disable the unescaping of URLs
     pub is_escaped_content: bool,
 }
@@ -17,7 +17,7 @@ pub struct Configuration {
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            namespace: String::from("esi"),
+            tag_names: Default::default(),
             is_escaped_content: true,
         }
     }
@@ -28,12 +28,48 @@ impl Configuration {
     ///
     /// For example, setting this to `test` would cause the processor to only match tags like `<test:include>`.
     pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
-        self.namespace = namespace.into();
+        self.tag_names = TagNames::from_namespace_with_defaults(&namespace.into());
+        self
+    }
+    /// Sets the tag names that the processor will operate on.
+    pub fn with_tag_names(mut self, tag_names: TagNames) -> Self {
+        self.tag_names = tag_names;
         self
     }
     /// For working with non-HTML ESI templates, eg JSON files, allows to disable URLs unescaping
     pub fn with_escaped(mut self, is_escaped: impl Into<bool>) -> Self {
         self.is_escaped_content = is_escaped.into();
         self
+    }
+}
+
+/// Defines the HTML tag names that the processor will operate on.
+#[derive(Clone, Debug)]
+pub struct TagNames {
+    pub include: Vec<u8>,
+    pub comment: Vec<u8>,
+    pub remove: Vec<u8>,
+    pub r#try: Vec<u8>,
+    pub attempt: Vec<u8>,
+    pub except: Vec<u8>,
+}
+
+impl TagNames {
+    /// Returns tag names as defined within the ESI specification within the given namespace.
+    pub fn from_namespace_with_defaults(namespace: &str) -> Self {
+        Self {
+            include: format!("{namespace}:include",).into_bytes(),
+            comment: format!("{namespace}:comment",).into_bytes(),
+            remove: format!("{namespace}:remove",).into_bytes(),
+            r#try: format!("{namespace}:try",).into_bytes(),
+            attempt: format!("{namespace}:attempt",).into_bytes(),
+            except: format!("{namespace}:except",).into_bytes(),
+        }
+    }
+}
+
+impl Default for TagNames {
+    fn default() -> Self {
+        Self::from_namespace_with_defaults("esi")
     }
 }

--- a/esi/src/config.rs
+++ b/esi/src/config.rs
@@ -27,6 +27,10 @@ impl Configuration {
     /// Sets an alternative ESI namespace, which is used to identify ESI instructions.
     ///
     /// For example, setting this to `test` would cause the processor to only match tags like `<test:include>`.
+    #[deprecated(
+        since = "0.6.0",
+        note = "This method is deprecated and will be removed in a future release. Use `with_tag_names(TagNames#from_namespace_with_defaults)` instead."
+    )]
     pub fn with_namespace(mut self, namespace: impl Into<String>) -> Self {
         self.tag_names = TagNames::from_namespace_with_defaults(&namespace.into());
         self

--- a/esi/src/config.rs
+++ b/esi/src/config.rs
@@ -3,7 +3,7 @@
 /// ## Usage Example
 /// ```rust,no_run
 /// let config = esi::Configuration::default()
-///     .with_namespace("app");
+///     .with_tag_names(esi::TagNames::from_namespace_with_defaults("app"));
 /// ```
 #[allow(clippy::return_self_not_must_use)]
 #[derive(Clone, Debug)]
@@ -60,6 +60,7 @@ pub struct TagNames {
 
 impl TagNames {
     /// Returns tag names as defined within the ESI specification within the given namespace.
+    /// e.g. if `namespace` is `esi`, the tag names will be `esi:include`, `esi:comment`, etc.
     pub fn from_namespace_with_defaults(namespace: &str) -> Self {
         Self {
             include: format!("{namespace}:include",).into_bytes(),

--- a/esi/src/lib.rs
+++ b/esi/src/lib.rs
@@ -13,12 +13,11 @@ use log::{debug, error, trace};
 use std::collections::VecDeque;
 use std::io::{BufRead, Write};
 
+pub use crate::config::{Configuration, TagNames};
 pub use crate::document::{Element, Fragment};
+pub use crate::error::ExecutionError;
 pub use crate::error::Result;
 pub use crate::parse::{parse_tags, Event, Include, Tag, Tag::Try};
-
-pub use crate::config::Configuration;
-pub use crate::error::ExecutionError;
 
 // re-export quick_xml Reader and Writer
 pub use quick_xml::{Reader, Writer};
@@ -147,7 +146,7 @@ impl Processor {
         // on each tag / event it finds in the document.
         // The callback function `handle_events` will handle the event.
         parse_tags(
-            &self.configuration.namespace,
+            &self.configuration.tag_names,
             &mut src_document,
             &mut |event| {
                 event_receiver(

--- a/esi/src/parse.rs
+++ b/esi/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::{ExecutionError, Result};
+use crate::{ExecutionError, Result, TagNames};
 use log::debug;
 use quick_xml::events::{BytesStart, Event as XmlEvent};
 use quick_xml::name::QName;
@@ -41,28 +41,6 @@ pub enum Tag<'a> {
 pub enum Event<'e> {
     XML(XmlEvent<'e>),
     ESI(Tag<'e>),
-}
-
-// #[derive(Debug)]
-struct TagNames {
-    include: Vec<u8>,
-    comment: Vec<u8>,
-    remove: Vec<u8>,
-    r#try: Vec<u8>,
-    attempt: Vec<u8>,
-    except: Vec<u8>,
-}
-impl TagNames {
-    fn init(namespace: &str) -> Self {
-        Self {
-            include: format!("{namespace}:include",).into_bytes(),
-            comment: format!("{namespace}:comment",).into_bytes(),
-            remove: format!("{namespace}:remove",).into_bytes(),
-            r#try: format!("{namespace}:try",).into_bytes(),
-            attempt: format!("{namespace}:attempt",).into_bytes(),
-            except: format!("{namespace}:except",).into_bytes(),
-        }
-    }
 }
 
 fn do_parse<'a, R>(
@@ -185,7 +163,7 @@ where
 
 /// Parses the ESI document from the given `reader` and calls the `callback` closure upon each successfully parsed ESI tag.
 pub fn parse_tags<'a, R>(
-    namespace: &str,
+    tag_names: &TagNames,
     reader: &mut Reader<R>,
     callback: &mut dyn FnMut(Event<'a>) -> Result<()>,
 ) -> Result<()>
@@ -194,8 +172,6 @@ where
 {
     debug!("Parsing document...");
 
-    // Initialize the ESI tags
-    let tags = TagNames::init(namespace);
     // set the initial depth of nested tags
     let mut depth = 0;
     let mut root = Vec::new();
@@ -208,7 +184,7 @@ where
         &mut root,
         &mut depth,
         &mut current_arm,
-        &tags,
+        tag_names,
     )?;
     debug!("Root: {:?}", root);
 

--- a/esi/tests/parse.rs
+++ b/esi/tests/parse.rs
@@ -1,4 +1,4 @@
-use esi::{parse_tags, Event, ExecutionError, Tag};
+use esi::{parse_tags, Event, ExecutionError, Tag, TagNames};
 use quick_xml::Reader;
 
 use std::sync::Once;
@@ -17,20 +17,24 @@ fn parse_basic_include() -> Result<(), ExecutionError> {
     let input = "<html><body><esi:include src=\"https://example.com/hello\"/></body></html>";
     let mut parsed = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        if let Event::ESI(Tag::Include {
-            src,
-            alt,
-            continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, "https://example.com/hello");
-            assert_eq!(alt, None);
-            assert!(!continue_on_error);
-            parsed = true;
-        }
-        Ok(())
-    })?;
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            if let Event::ESI(Tag::Include {
+                src,
+                alt,
+                continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, "https://example.com/hello");
+                assert_eq!(alt, None);
+                assert!(!continue_on_error);
+                parsed = true;
+            }
+            Ok(())
+        },
+    )?;
 
     assert!(parsed);
 
@@ -44,20 +48,24 @@ fn parse_advanced_include_with_namespace() -> Result<(), ExecutionError> {
     let input = "<app:include src=\"abc\" alt=\"def\" onerror=\"continue\"/>";
     let mut parsed = false;
 
-    parse_tags("app", &mut Reader::from_str(input), &mut |event| {
-        if let Event::ESI(Tag::Include {
-            src,
-            alt,
-            continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, "abc");
-            assert_eq!(alt, Some("def".to_string()));
-            assert!(continue_on_error);
-            parsed = true;
-        }
-        Ok(())
-    })?;
+    parse_tags(
+        &TagNames::from_namespace_with_defaults("app"),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            if let Event::ESI(Tag::Include {
+                src,
+                alt,
+                continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, "abc");
+                assert_eq!(alt, Some("def".to_string()));
+                assert!(continue_on_error);
+                parsed = true;
+            }
+            Ok(())
+        },
+    )?;
 
     assert!(parsed);
 
@@ -71,20 +79,24 @@ fn parse_open_include() -> Result<(), ExecutionError> {
     let input = "<esi:include src=\"abc\" alt=\"def\" onerror=\"continue\"></esi:include>";
     let mut parsed = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        if let Event::ESI(Tag::Include {
-            src,
-            alt,
-            continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, "abc");
-            assert_eq!(alt, Some("def".to_string()));
-            assert!(continue_on_error);
-            parsed = true;
-        }
-        Ok(())
-    })?;
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            if let Event::ESI(Tag::Include {
+                src,
+                alt,
+                continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, "abc");
+                assert_eq!(alt, Some("def".to_string()));
+                assert!(continue_on_error);
+                parsed = true;
+            }
+            Ok(())
+        },
+    )?;
 
     assert!(parsed);
 
@@ -97,7 +109,11 @@ fn parse_invalid_include() -> Result<(), ExecutionError> {
 
     let input = "<esi:include/>";
 
-    let res = parse_tags("esi", &mut Reader::from_str(input), &mut |_| Ok(()));
+    let res = parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |_| Ok(()),
+    );
 
     assert!(matches!(
         res,
@@ -114,21 +130,25 @@ fn parse_basic_include_with_onerror() -> Result<(), ExecutionError> {
     let input = "<esi:include src=\"/_fragments/content.html\" onerror=\"continue\"/>";
     let mut parsed = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        if let Event::ESI(Tag::Include {
-            src,
-            alt,
-            continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, "/_fragments/content.html");
-            assert_eq!(alt, None);
-            assert!(continue_on_error);
-            parsed = true;
-        }
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            if let Event::ESI(Tag::Include {
+                src,
+                alt,
+                continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, "/_fragments/content.html");
+                assert_eq!(alt, None);
+                assert!(continue_on_error);
+                parsed = true;
+            }
 
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
 
     assert!(parsed);
 
@@ -142,20 +162,24 @@ fn parse_try_accept_only_include() -> Result<(), ExecutionError> {
     let input = "<esi:try><esi:attempt><esi:include src=\"abc\" alt=\"def\" onerror=\"continue\"/></esi:attempt></esi:try>";
     let mut parsed = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        if let Event::ESI(Tag::Include {
-            src,
-            alt,
-            continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, "abc");
-            assert_eq!(alt, Some("def".to_string()));
-            assert!(continue_on_error);
-            parsed = true;
-        }
-        Ok(())
-    })?;
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            if let Event::ESI(Tag::Include {
+                src,
+                alt,
+                continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, "abc");
+                assert_eq!(alt, Some("def".to_string()));
+                assert!(continue_on_error);
+                parsed = true;
+            }
+            Ok(())
+        },
+    )?;
 
     assert!(!parsed);
 
@@ -181,56 +205,60 @@ fn parse_try_accept_except_include() -> Result<(), ExecutionError> {
     let mut accept_include_parsed = false;
     let mut except_include_parsed = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        println!("Event - {event:?}");
-        if let Event::ESI(Tag::Include {
-            ref src,
-            ref alt,
-            ref continue_on_error,
-        }) = event
-        {
-            assert_eq!(src, &"/foo");
-            assert_eq!(alt, &None);
-            assert!(!continue_on_error);
-            plain_include_parsed = true;
-        }
-        if let Event::ESI(Tag::Try {
-            attempt_events,
-            except_events,
-        }) = event
-        {
-            // process accept tasks
-            for attempt_event in attempt_events {
-                if let Event::ESI(Tag::Include {
-                    src,
-                    alt,
-                    continue_on_error,
-                }) = attempt_event
-                {
-                    assert_eq!(src, "/abc");
-                    assert_eq!(alt, None);
-                    assert!(!continue_on_error);
-                    accept_include_parsed = true;
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            println!("Event - {event:?}");
+            if let Event::ESI(Tag::Include {
+                ref src,
+                ref alt,
+                ref continue_on_error,
+            }) = event
+            {
+                assert_eq!(src, &"/foo");
+                assert_eq!(alt, &None);
+                assert!(!continue_on_error);
+                plain_include_parsed = true;
+            }
+            if let Event::ESI(Tag::Try {
+                attempt_events,
+                except_events,
+            }) = event
+            {
+                // process accept tasks
+                for attempt_event in attempt_events {
+                    if let Event::ESI(Tag::Include {
+                        src,
+                        alt,
+                        continue_on_error,
+                    }) = attempt_event
+                    {
+                        assert_eq!(src, "/abc");
+                        assert_eq!(alt, None);
+                        assert!(!continue_on_error);
+                        accept_include_parsed = true;
+                    }
+                }
+                // process except tasks
+                for except_event in except_events {
+                    if let Event::ESI(Tag::Include {
+                        src,
+                        alt,
+                        continue_on_error,
+                    }) = except_event
+                    {
+                        assert_eq!(src, "/xyz");
+                        assert_eq!(alt, None);
+                        assert!(!continue_on_error);
+                        except_include_parsed = true;
+                    }
                 }
             }
-            // process except tasks
-            for except_event in except_events {
-                if let Event::ESI(Tag::Include {
-                    src,
-                    alt,
-                    continue_on_error,
-                }) = except_event
-                {
-                    assert_eq!(src, "/xyz");
-                    assert_eq!(alt, None);
-                    assert!(!continue_on_error);
-                    except_include_parsed = true;
-                }
-            }
-        }
 
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
 
     assert!(!plain_include_parsed);
     assert!(accept_include_parsed);
@@ -266,79 +294,83 @@ fn parse_try_nested() -> Result<(), ExecutionError> {
     let mut accept_include_parsed_level2 = false;
     let mut except_include_parsed_level2 = false;
 
-    parse_tags("esi", &mut Reader::from_str(input), &mut |event| {
-        assert_eq!(
-            format!("{event:?}"),
-            r#"ESI(Try { attempt_events: [XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Include { src: "/abc", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA        ") })), XML(Text(BytesText { content: Owned("0xA            ") })), XML(Text(BytesText { content: Owned("0xA                ") })), XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Try { attempt_events: [XML(Text(BytesText { content: Owned("0xA                ") })), ESI(Include { src: "/foo", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA            ") }))], except_events: [XML(Text(BytesText { content: Owned("0xA                ") })), ESI(Include { src: "/bar", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA                ") }))] }), XML(Text(BytesText { content: Owned("0xA    ") }))], except_events: [XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Include { src: "/xyz", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA        ") })), XML(Empty(BytesStart { buf: Owned("a href=\"/efg\""), name_len: 1 })), XML(Text(BytesText { content: Owned("0xA        just text0xA    ") }))] })"#
-        );
-        if let Event::ESI(Tag::Try {
-            attempt_events,
-            except_events,
-        }) = event
-        {
-            for event in attempt_events {
-                if let Event::ESI(Tag::Include {
-                    ref src,
-                    ref alt,
-                    ref continue_on_error,
-                }) = event
-                {
-                    assert_eq!(src, &"/abc");
-                    assert_eq!(alt, &None);
-                    assert!(!continue_on_error);
-                    accept_include_parsed_level1 = true;
-                }
-                if let Event::ESI(Tag::Try {
-                    attempt_events,
-                    except_events,
-                }) = event
-                {
-                    for event in attempt_events {
-                        if let Event::ESI(Tag::Include {
-                            ref src,
-                            ref alt,
-                            ref continue_on_error,
-                        }) = event
-                        {
-                            assert_eq!(src, &"/foo");
-                            assert_eq!(alt, &None);
-                            assert!(!continue_on_error);
-                            accept_include_parsed_level2 = true;
+    parse_tags(
+        &Default::default(),
+        &mut Reader::from_str(input),
+        &mut |event| {
+            assert_eq!(
+                format!("{event:?}"),
+                r#"ESI(Try { attempt_events: [XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Include { src: "/abc", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA        ") })), XML(Text(BytesText { content: Owned("0xA            ") })), XML(Text(BytesText { content: Owned("0xA                ") })), XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Try { attempt_events: [XML(Text(BytesText { content: Owned("0xA                ") })), ESI(Include { src: "/foo", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA            ") }))], except_events: [XML(Text(BytesText { content: Owned("0xA                ") })), ESI(Include { src: "/bar", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA                ") }))] }), XML(Text(BytesText { content: Owned("0xA    ") }))], except_events: [XML(Text(BytesText { content: Owned("0xA        ") })), ESI(Include { src: "/xyz", alt: None, continue_on_error: false }), XML(Text(BytesText { content: Owned("0xA        ") })), XML(Empty(BytesStart { buf: Owned("a href=\"/efg\""), name_len: 1 })), XML(Text(BytesText { content: Owned("0xA        just text0xA    ") }))] })"#
+            );
+            if let Event::ESI(Tag::Try {
+                attempt_events,
+                except_events,
+            }) = event
+            {
+                for event in attempt_events {
+                    if let Event::ESI(Tag::Include {
+                        ref src,
+                        ref alt,
+                        ref continue_on_error,
+                    }) = event
+                    {
+                        assert_eq!(src, &"/abc");
+                        assert_eq!(alt, &None);
+                        assert!(!continue_on_error);
+                        accept_include_parsed_level1 = true;
+                    }
+                    if let Event::ESI(Tag::Try {
+                        attempt_events,
+                        except_events,
+                    }) = event
+                    {
+                        for event in attempt_events {
+                            if let Event::ESI(Tag::Include {
+                                ref src,
+                                ref alt,
+                                ref continue_on_error,
+                            }) = event
+                            {
+                                assert_eq!(src, &"/foo");
+                                assert_eq!(alt, &None);
+                                assert!(!continue_on_error);
+                                accept_include_parsed_level2 = true;
+                            }
+                        }
+                        for event in except_events {
+                            if let Event::ESI(Tag::Include {
+                                ref src,
+                                ref alt,
+                                ref continue_on_error,
+                            }) = event
+                            {
+                                assert_eq!(src, &"/bar");
+                                assert_eq!(alt, &None);
+                                assert!(!continue_on_error);
+                                except_include_parsed_level2 = true;
+                            }
                         }
                     }
-                    for event in except_events {
-                        if let Event::ESI(Tag::Include {
-                            ref src,
-                            ref alt,
-                            ref continue_on_error,
-                        }) = event
-                        {
-                            assert_eq!(src, &"/bar");
-                            assert_eq!(alt, &None);
-                            assert!(!continue_on_error);
-                            except_include_parsed_level2 = true;
-                        }
+                }
+
+                for event in except_events {
+                    if let Event::ESI(Tag::Include {
+                        ref src,
+                        ref alt,
+                        ref continue_on_error,
+                    }) = event
+                    {
+                        assert_eq!(src, &"/xyz");
+                        assert_eq!(alt, &None);
+                        assert!(!continue_on_error);
+                        except_include_parsed_level1 = true;
                     }
                 }
             }
 
-            for event in except_events {
-                if let Event::ESI(Tag::Include {
-                    ref src,
-                    ref alt,
-                    ref continue_on_error,
-                }) = event
-                {
-                    assert_eq!(src, &"/xyz");
-                    assert_eq!(alt, &None);
-                    assert!(!continue_on_error);
-                    except_include_parsed_level1 = true;
-                }
-            }
-        }
-
-        Ok(())
-    })?;
+            Ok(())
+        },
+    )?;
 
     assert!(accept_include_parsed_level1);
     assert!(accept_include_parsed_level2);


### PR DESCRIPTION
This change makes it possible to provide custom tag names for the parser rather than just configuring the namespace.