### PR TITLE
Custom Parser

### DIFF
--- a/esi/Cargo.toml
+++ b/esi/Cargo.toml
@@ -15,6 +15,7 @@ fastly = "^0.11"
 log = "^0.4"
 regex = "1.11.1"
 html-escape = "0.2.13"
+nom = "7.1.3"
 
 [dev-dependencies]
 env_logger = "^0.11"

--- a/esi/src/lib.rs
+++ b/esi/src/lib.rs
@@ -7,6 +7,7 @@ mod expression;
 mod functions;
 mod new_parse;
 mod parse;
+mod parser_types;
 
 use document::{FetchState, Task};
 use expression::{logged_evaluate_expression, maybe_evaluate_interpolated, EvalContext};

--- a/esi/src/lib.rs
+++ b/esi/src/lib.rs
@@ -5,6 +5,7 @@ mod document;
 mod error;
 mod expression;
 mod functions;
+mod new_parse;
 mod parse;
 
 use document::{FetchState, Task};

--- a/esi/src/lib.rs
+++ b/esi/src/lib.rs
@@ -20,6 +20,7 @@ use std::io::{BufRead, Write};
 
 pub use crate::document::{Element, Fragment};
 pub use crate::error::Result;
+pub use crate::new_parse::parse;
 pub use crate::parse::{parse_tags, Event, Include, Tag, Tag::Try};
 
 pub use crate::config::Configuration;

--- a/esi/src/new_parse.rs
+++ b/esi/src/new_parse.rs
@@ -1,0 +1,116 @@
+use nom::branch::alt;
+use nom::bytes::streaming::*;
+use nom::character::streaming::*;
+use nom::combinator::{complete, map, recognize, success};
+use nom::error::Error;
+use nom::multi::fold_many0;
+use nom::sequence::{delimited, pair, preceded, separated_pair};
+use nom::IResult;
+
+#[derive(Debug)]
+enum Chunk<'a> {
+    EsiStartTag(&'a str, Vec<(&'a str, &'a str)>),
+    EsiEndTag(&'a str),
+    Text(&'a str),
+}
+
+fn parse(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    fold_many0(
+        complete(chunk),
+        Vec::new,
+        |mut acc: Vec<Chunk>, mut item| {
+            acc.append(&mut item);
+            acc
+        },
+    )(input)
+}
+
+fn chunk(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    alt((text, alt((esi_tag, html))))(input)
+}
+
+fn esi_tag(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    alt((esi_start_tag, esi_end_tag))(input)
+}
+fn esi_start_tag(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(
+        delimited(tag("<esi:"), pair(esi_tag_name, attributes), char('>')),
+        |(tagname, attrs)| vec![Chunk::EsiStartTag(tagname, attrs)],
+    )(input)
+}
+fn esi_end_tag(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(
+        delimited(tag("</esi:"), is_not(">"), char('>')),
+        |s: &str| vec![Chunk::EsiEndTag(s)],
+    )(input)
+}
+
+fn esi_tag_name(input: &str) -> IResult<&str, &str, Error<&str>> {
+    tag("vars")(input)
+}
+
+fn attributes(input: &str) -> IResult<&str, Vec<(&str, &str)>, Error<&str>> {
+    map(
+        separated_pair(preceded(multispace1, alpha1), char('='), xmlstring),
+        |(name, value)| vec![(name, value)],
+    )(input)
+}
+
+fn xmlstring(input: &str) -> IResult<&str, &str, Error<&str>> {
+    delimited(char('"'), is_not("\""), char('"'))(input) // TODO: obviously wrong
+}
+
+fn html(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    alt((script, end_tag, start_tag))(input)
+}
+
+fn script(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(
+        recognize(delimited(
+            delimited(tag("<script"), alt((is_not(">"), success(""))), char('>')),
+            take_until("</script"),
+            delimited(tag("</script"), alt((is_not(">"), success(""))), char('>')),
+        )),
+        |s: &str| vec![Chunk::Text(s)],
+    )(input)
+}
+
+fn end_tag(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(
+        recognize(delimited(tag("</"), is_not(">"), char('>'))),
+        |s: &str| vec![Chunk::Text(s)],
+    )(input)
+}
+
+fn start_tag(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(
+        recognize(delimited(char('<'), is_not(">"), char('>'))),
+        |s: &str| vec![Chunk::Text(s)],
+    )(input)
+}
+fn text(input: &str) -> IResult<&str, Vec<Chunk>, Error<&str>> {
+    map(take_until1("<"), |s: &str| vec![Chunk::Text(s)])(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_parse() {
+        let x = parse(
+            "<a>foo</a><bar />baz<esi:vars name=\"$hello\"><baz><script> less < more </script>",
+        );
+        println!("{:?}", x);
+    }
+    #[test]
+    fn test_new_parse_script() {
+        let x = script("<script> less < more </script>");
+        println!("{:?}", x);
+    }
+    #[test]
+    fn test_new_parse_esi_tag() {
+        let x = esi_start_tag("<esi:vars foo=\"hello\">");
+        println!("{:?}", x);
+    }
+}

--- a/esi/src/parser_types.rs
+++ b/esi/src/parser_types.rs
@@ -1,0 +1,21 @@
+#[derive(Debug)]
+pub enum Tag {
+    Vars,
+    Include,
+    Text,
+    Choose,
+    When,
+    Otherwise,
+    Try,
+    Attempt,
+    Except,
+}
+
+#[derive(Debug)]
+pub enum Chunk<'a> {
+    EsiStartTag(Tag, Vec<(&'a str, &'a str)>),
+    EsiEndTag(Tag),
+    Expr(&'a str),
+    Html(&'a str),
+    Text(&'a str),
+}

--- a/esi/src/parser_types.rs
+++ b/esi/src/parser_types.rs
@@ -26,7 +26,26 @@ pub enum Symbol<'e> {
 #[derive(Debug, PartialEq, Clone)]
 pub enum Chunk<'a> {
     Esi(Tag<'a>),
-    Expr(Symbol<'a>),
+    Expr(Expr<'a>),
     Html(&'a str),
     Text(&'a str),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Expr<'a> {
+    Integer(i32),
+    String(Option<&'a str>),
+    Variable(&'a str, Option<&'a str>, Option<Box<Expr<'a>>>),
+    Comparison {
+        left: Box<Expr<'a>>,
+        operator: Operator,
+        right: Box<Expr<'a>>,
+    },
+    Call(&'a str, Vec<Expr<'a>>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Operator {
+    Matches,
+    MatchesInsensitive,
 }

--- a/esi/src/parser_types.rs
+++ b/esi/src/parser_types.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Tag<'a> {
     Include(Vec<(&'a str, &'a str)>),
     Choose(Vec<Chunk<'a>>, Option<Vec<Chunk<'a>>>),
@@ -10,10 +10,23 @@ pub enum Tag<'a> {
     Assign(Vec<(&'a str, &'a str)>, Option<Vec<Chunk<'a>>>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
+pub enum Symbol<'e> {
+    Function {
+        name: &'e str,
+        args: Vec<Symbol<'e>>,
+    },
+    Variable {
+        name: &'e str,
+        key: Option<&'e str>,
+        default: Option<Box<Symbol<'e>>>,
+    },
+    String(Option<&'e str>),
+}
+#[derive(Debug, PartialEq, Clone)]
 pub enum Chunk<'a> {
     Esi(Tag<'a>),
-    Expr(&'a str),
+    Expr(Symbol<'a>),
     Html(&'a str),
     Text(&'a str),
 }

--- a/esi/src/parser_types.rs
+++ b/esi/src/parser_types.rs
@@ -1,20 +1,18 @@
-#[derive(Debug)]
-pub enum Tag {
-    Vars,
-    Include,
-    Text,
-    Choose,
-    When,
-    Otherwise,
-    Try,
-    Attempt,
-    Except,
+#[derive(Debug, Clone)]
+pub enum Tag<'a> {
+    Include(Vec<(&'a str, &'a str)>),
+    Choose(Vec<Chunk<'a>>, Option<Vec<Chunk<'a>>>),
+    When(Vec<(&'a str, &'a str)>, Vec<Chunk<'a>>),
+    Otherwise(Vec<Chunk<'a>>),
+    Try(Vec<Vec<Chunk<'a>>>, Option<Vec<Chunk<'a>>>),
+    Attempt(Vec<Chunk<'a>>),
+    Except(Vec<Chunk<'a>>),
+    Assign(Vec<(&'a str, &'a str)>, Option<Vec<Chunk<'a>>>),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Chunk<'a> {
-    EsiStartTag(Tag, Vec<(&'a str, &'a str)>),
-    EsiEndTag(Tag),
+    Esi(Tag<'a>),
     Expr(&'a str),
     Html(&'a str),
     Text(&'a str),

--- a/examples/esi_vars_example/src/index.html
+++ b/examples/esi_vars_example/src/index.html
@@ -52,7 +52,7 @@
         </esi:when>
         <esi:otherwise>
           GOODBYE
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
       
@@ -64,7 +64,7 @@
         </esi:when>
         <esi:otherwise>
           GOODBYE
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -79,7 +79,7 @@
         </esi:when>
         <esi:otherwise>
           GOODBYE
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
       
@@ -94,7 +94,7 @@
         </esi:when>
         <esi:otherwise>
           GOODBYE
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
       
@@ -109,7 +109,7 @@
         </esi:when>
         <esi:otherwise>
           GOODBYE
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -121,7 +121,7 @@
         </esi:when>
         <esi:otherwise>
           UH OH
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -132,7 +132,7 @@
         </esi:when>
         <esi:otherwise>
           NO
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -143,7 +143,7 @@
         </esi:when>
         <esi:otherwise>
           NO
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -155,7 +155,7 @@
         </esi:when>
         <esi:otherwise>
           UH OH
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -167,7 +167,7 @@
         </esi:when>
         <esi:otherwise>
           NO
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -178,7 +178,7 @@
         </esi:when>
         <esi:otherwise>
           UH OH
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -189,7 +189,7 @@
         </esi:when>
         <esi:otherwise>
           UH OH
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 
@@ -202,7 +202,7 @@
         </esi:when>
         <esi:otherwise>
           UH OH
-        </esi:when>
+        </esi:otherwise>
       </esi:choose>
       <br>
 


### PR DESCRIPTION
Just a draft to start with. 

This attempts to implement a parser specifically for ESI, which largely ignores the surrounding document. As a few issues have noted, currently we trip over some invalid (and also valid) HTML because we're using an XML parser to find the ESI tags. 

That leaves us in the unfortunate position of not being able to use an XML parser to find XML, and so needing to use a heavyweight HTML parser just so we can ignore it. Somehow I've developed the audacity to think that we could get around this by building a custom parser that knows just enough about HTML to get around its foibles while also finding the ESI XML tags. We'll see. 

Upsides of this, in addition to not tripping on `<` inside javascript blocks are that we can integrate the tag parsing and the expression parsing and just turn the whole thing into a stream of tokens that either get splatted out onto the wire or run through an interpreter and then splatted out onto the wire, which can be done in a completely streaming fashion.

Downsides are the 40 years of shenanigans inside HTML. This is going to require some serious testing to have any confidence in.

Goals:
* Documents without ESI should make it through completely unchanged
* Don't trip on HTML shenanigans when parsing ESI
* Correctly identify interpolated expressions inside ESI blocks
* Everything should be streaming, no blocking while the whole document buffers

Non-goals:
* Parsing HTML. We need to identify it and ignore it, not validate it and not break it.
* ...?