### PR TITLE
Add release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,30 +7,10 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
     permissions:
       id-token: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Verify tag matches crate version
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "esi") | .version')
-          if [ "$TAG" != "$CRATE_VERSION" ]; then
-            echo "::error::Tag version ($TAG) does not match crate version ($CRATE_VERSION)"
-            exit 1
-          fi
-
-      - name: Authenticate with crates.io
-        uses: rust-lang/crates-io-auth-action@v1
-        id: auth
-
-      - name: Publish to crates.io
-        run: cargo publish -p esi
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+      contents: read
+    uses: fastly/devex-reusable-workflows/.github/workflows/publish-rust-crates-io-v1.yml@main
+    with:
+      crate_name: esi
+      expected_version: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify tag matches crate version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          CRATE_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "esi") | .version')
+          if [ "$TAG" != "$CRATE_VERSION" ]; then
+            echo "::error::Tag version ($TAG) does not match crate version ($CRATE_VERSION)"
+            exit 1
+          fi
+
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish to crates.io
+        run: cargo publish -p esi
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing
+
+1. **Create a release branch**:
+
+   ```sh
+   git checkout main
+   git pull
+   git checkout -b release/vX.Y.Z
+   ```
+
+2. **Update the version** in [Cargo.toml](Cargo.toml) under `[workspace.package]`:
+
+   ```toml
+   [workspace.package]
+   version = "X.Y.Z"
+   ```
+
+3. **Regenerate the lockfile**:
+
+   ```sh
+   cargo generate-lockfile
+   ```
+
+4. **Commit and push the version bump**:
+
+   ```sh
+   git add Cargo.toml Cargo.lock
+   git commit -m "Release vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   ```
+
+5. **Open a pull request** into `main` and get it merged.
+
+6. **Tag the release from `main`**:
+
+   ```sh
+   git checkout main
+   git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   The tag must match the pattern `vX.Y.Z` and the version in `Cargo.toml`.
+
+7. **Monitor the release**. The [Release workflow](.github/workflows/release.yml) will automatically verify the tag matches the crate version and publish to [crates.io](https://crates.io/crates/esi).
+
+   You can follow progress in the **Actions** tab of the repository.


### PR DESCRIPTION
This pull request adds a workflow to automatically publish the crate to crates.io when a new release is tagged, and adds a document to explain how to trigger this.

The Trusted Publishing configuration is already set on crates.io:
<img width="975" height="314" alt="Screenshot 2026-05-05 at 16 58 19" src="https://github.com/user-attachments/assets/f68974b0-852e-4877-80f2-a179067f0b58" />
