### PR TITLE
Release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -144,9 +144,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -340,9 +340,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elsa"
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "fastly"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16393f187c703d5460d095201e194940a190479cd5a45aa7e324e8c97f4a3df4"
+checksum = "531e4c3df48350d9f4fc95b4deaf87fd29820336b7926bb84bf460457c2a126b"
 dependencies = [
  "anyhow",
  "bytes",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-macros"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e11b9b78e4d8d0fab4b9d7d8ba289c30d62d641e649e89153bc4d5446c88db2"
+checksum = "cc2aef5f9690b04c8890f9a54ddb591b12b9779ec25ee0e572d207106e52e3d8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -506,9 +506,9 @@ dependencies = [
 
 [[package]]
 name = "fastly-shared"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ca5a9664c64b9f85188426aa1598e9885d6dbb247d6155fd9ebe043b551800"
+checksum = "080ad138403159fd366d3e0b14bb49cb0c01dc18c25095bbbd1c85e3338f5413"
 dependencies = [
  "bitflags 1.3.2",
  "http",
@@ -516,15 +516,15 @@ dependencies = [
 
 [[package]]
 name = "fastly-sys"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dacc6ac7a7400e0b38757f48fbf1db09971812ef3dbb1f1a90a50746df662f"
+checksum = "de75ef193f6c29c43d667458bede648970715aedd5db2d42c2eba3ffa3ad738b"
 dependencies = [
  "bitflags 1.3.2",
  "fastly-shared",
  "http",
  "wasip2",
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -546,6 +546,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -594,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -621,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -754,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -769,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -817,9 +841,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -830,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -841,10 +865,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -863,9 +889,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "litemap"
@@ -875,9 +901,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "md5"
@@ -887,9 +913,9 @@ checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -908,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -950,6 +976,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -1120,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1169,9 +1201,15 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1310,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -1374,11 +1412,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1387,14 +1425,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1405,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1415,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1428,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -1557,6 +1595,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1666,18 +1713,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1686,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]


### PR DESCRIPTION
# Release v0.7.0

Complete rewrite of the ESI parser from XML-based to nom-based parsing with full streaming support, comprehensive expression evaluation, and a rich function library.

Based on [#43](https://github.com/fastly/esi/pull/43) and subsequent improvements.

## Breaking Changes

- Parser rewritten from `quick-xml` to `nom` — public API changed from `Reader`/`Writer`/`parse_tags` to `process_stream` with `BufReader`
- Fragment dispatcher signature updated (`|req, _maxwait|`)
- Minimum `fastly` dependency bumped to `^0.12`
- Rust toolchain updated to `1.95.0`

## New Features

### New ESI Tags

- `<esi:eval>` — fetches content and always parses it as ESI (blocking operation), with `dca` support for two-phase processing
- `<esi:param>` — nested inside include/eval for query parameter injection
- `<esi:foreach>` / `<esi:break>` — iteration over lists and dicts
- `<esi:function>` / `<esi:return>` — user-defined functions with recursion depth control
- `<esi:text>` — raw passthrough (content emitted verbatim, no ESI processing)

### Expression Engine

- List literals (`['a', 'b', 'c']`) and dictionary literals (`{'key1': 'val1', 'key2': 'val2'}`)
- Mixed-type lists: lists can contain strings, integers, dicts, and nested lists (e.g. `['one', 2, ['nested']]`)
- Range literals (`[1..10]`)
- Dynamic subkeys: `$(VAR{$(dynamic_key)})`
- Operators: `has`, `has_i`, `matches`, `matches_i`, `+`, `-`, `*`, `/`, `%`
- Type coercion for operators: mixed-type operands are stringified for comparison (e.g. `3 == '3'` is `true`); `+` does integer addition when both operands are integers (e.g. `3 + 4` = `7`), list concatenation for two lists, string concatenation otherwise (e.g. `3 + '4'` = `'34'`); `*` does integer multiplication, or string/list repetition with an integer count (e.g. `3 * 'ab'` = `'ababab'`); expressions evaluate left to right, so `2 + 8 + ' days'` = `'10 days'`; `-`, `/`, `%` require integer operands
- Function argument coercion: built-in functions coerce arguments as needed (e.g. `$int` parses strings to integers, `$substr` coerces index args)
- Function calls: `$fn_name(args...)` with nested calls supported
- Backslash escaping in strings and interpolated content (`\'`, `\\`, `\$`, `\<`)

### Function Library

- **String:** `$upper`, `$lstrip`, `$rstrip`, `$strip`, `$substr`
- **Encoding:** `$html_decode`, `$url_encode`, `$url_decode`, `$base64_encode`, `$base64_decode`, `$convert_to_unicode`, `$convert_from_unicode`
- **Quote helpers:** `$dollar`, `$dquote`, `$squote`
- **Collections:** `$len`, `$exists`, `$is_empty`, `$index`, `$rindex`, `$string_split`, `$join`, `$list_delitem`
- **Type conversion:** `$int`, `$str`
- **Crypto:** `$digest_md5`, `$digest_md5_hex`, `$bin_int`
- **Time:** `$time`, `$http_time`, `$strftime`
- **Random:** `$rand`, `$last_rand`
- **Response manipulation:** `$add_header`, `$set_response_code`, `$set_redirect`
- **User-defined:** nesting, recursion, and positional argument passing via `<esi:function>` / `<esi:return>`

### Variable System

- Types: integer, string, list, dict, boolean, null — with subscript get/set (strings support char index access)
- Default values: `$(VAR|'fallback')` — if undefined, the default expression is used
- Reference semantics: lists and dicts are assigned by reference — mutations are shared across aliases
- Request headers: `$(HTTP_*)` maps any prefix to the corresponding header; `$(HTTP_COOKIE{'name'})` for cookies, `$(QUERY_STRING{'param'})` for query params
- Request metadata: `$(REQUEST_METHOD)`, `$(REQUEST_PATH)`, `$(REMOTE_ADDR)`
- Function arguments: `$(ARGS)` / `$(ARGS{n})` for positional access
- Regex captures: `$(MATCHES{n})` populated by `matches` / `matches_i` operators

### DCA Configuration

- `default_dca` config option for DCA inheritance
- `inherit_parent_dca` for subtree DCA inheritance
- `Edge-Control` header support for per-fragment DCA control
- `max_include_depth` config with depth limit enforcement
- DCA configuration example

### Streaming Processing

- Pre-parsed attribute expressions — all include/eval attributes (`src`, `alt`, `dca`, `ttl`, `method`, `entity`, headers, params) are parsed into expression ASTs during parsing, then fully evaluated before each request is dispatched
- Flat-buffer slot design — all content (text, include responses, try-block outputs) assigned sequential `buf` slots for ordered flushing
- Concurrent fragment fetching via `fastly::http::request::select` — replaces sequential `.wait()` calls; all pending includes share a single pool and responses are harvested as they arrive while preserving document order
- Request correlation using `RequestKey` (method + URL) mapped through `url_map` to `SlotEntry`
- DCA modes: `dca="none"` (raw insertion) and `dca="esi"` (parse response as ESI)
- Try-block resolution: `TryBlockTracker` with per-attempt slot tracking, failure propagation, and except-block fallback via `assemble_try_block`
- TTL tracking for rendered document caching with `CacheConfig`

### Configuration

- `chunk_size` — streaming read buffer size
- `function_recursion_depth` — max user-defined function call depth
- `CacheConfig` — rendered output caching and cache-control header generation
- `expose-internals` feature flag for benchmarking

## Improved Features

- `<esi:include>` — now with full attribute set: `src`, `alt`, `dca`, `ttl`, `maxwait`, `no-store`, `method`, `entity`, `onerror`, `appendheader`, `setheader`, `removeheader` (previously only `src`, `alt`, `onerror`)
- `<esi:try>` / `<esi:attempt>` / `<esi:except>` — now supports parallel execution with multiple `<esi:attempt>` blocks
- `<esi:vars>` — now supports short form (`name=` attribute) and long form (with body)
- `<esi:assign>` — now with short and long form
- `<esi:choose>` / `<esi:when>` / `<esi:otherwise>` — now with pre-parsed expression evaluation
- `$lower` — now handles edge cases properly
- `$html_encode` — encodes 4 special characters per ESI spec (`>`, `<`, `&`, `"`)
- `$replace` — now supports optional count parameter
- Isolated namespace for ESI includes with `dca="esi"`

## Fixes

- Flush output writer during streaming to enable progressive rendering and prevent stalling
- Enhanced error handling in expression evaluation and fragment processing

## Testing

- Comprehensive unit tests in `parser.rs`: tag parsing, expression parsing, operator precedence, backslash escapes, variable name validation, subkey assignment
- Integration tests in `esi_tests.rs`: end-to-end processing with fragment dispatching, configuration options, variable evaluation
- Streaming behavior tests in `streaming_behavior.rs`: incomplete tag detection for all ESI tag types
- Parser tests in `tests/parser.rs`: try/attempt/except, include attributes, header manipulation
- Eval tests in `tests/eval_tests.rs`: DCA modes, eval vs include behavior
- DCA configuration tests: comprehensive coverage for all DCA config options
- Function tests in `functions.rs`: all built-in functions
- Expression tests in `expression.rs`: function calls, HTML encoding, evaluation

## Benchmarks

- `parser_benchmarks` — direct comparison with old XML parser using identical test cases (`esi_documents` group)
- `nom_parser_features` — HTML comments, script tags, assigns, advanced expressions, mixed content
- `parser_scaling` — 100 to 10,000 element documents
- `expression_parsing` — variable access, comparisons, logical operators, function calls
- `interpolated_strings` — text with embedded expressions

## Examples

All existing examples updated to work with the new API:

- `esi_example_minimal` — updated fragment dispatcher signature
- `esi_example_advanced_error_handling` — migrated from `Reader`/`Writer`/`parse_tags` to `process_stream` with `BufReader`
- `esi_try_example` — updated fragment dispatcher signature
- `esi_vars_example` — updated fragment dispatcher signature
- `esi_example_variants` — migrated from `parse_tags` + `process_parsed_document` + URL map to `process_stream` with inline URL rewriting
- `esi_dca_example` — new DCA configuration example
